### PR TITLE
infra: Add Freenode IRC cloak documentation (closes #9)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 recommonmark = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"
+sphinx-markdown-tables = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3fa25592848ef814e2b957544e9377506618e64d4234db55b52e0ba4177ab1f7"
+            "sha256": "e97cf3d7e87f3a8a11e202d4744adbeb7f1a3fca4b8f6bcecbb881a2d366af60"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,17 +25,17 @@
         },
         "babel": {
             "hashes": [
-                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
-                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
+                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
+                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
             ],
-            "version": "==2.7.0"
+            "version": "==2.8.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "chardet": {
             "hashes": [
@@ -53,11 +53,10 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
-                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
-                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
+                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
-            "version": "==0.15.2"
+            "version": "==0.16"
         },
         "idna": {
             "hashes": [
@@ -68,17 +67,24 @@
         },
         "imagesize": {
             "hashes": [
-                "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
-                "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
+                "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
+                "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
-            "version": "==1.1.0"
+            "version": "==1.2.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
-                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
+                "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250",
+                "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
             ],
-            "version": "==2.10.3"
+            "version": "==2.11.1"
+        },
+        "markdown": {
+            "hashes": [
+                "sha256:c00429bd503a47ec88d5e30a751e147dcb4c6889663cd3e2ba0afe858e009baa",
+                "sha256:d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c"
+            ],
+            "version": "==3.0.1"
         },
         "markupsafe": {
             "hashes": [
@@ -86,13 +92,16 @@
                 "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
                 "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
                 "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
                 "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
                 "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
                 "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
                 "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
                 "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
@@ -109,30 +118,32 @@
                 "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
                 "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
                 "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
-                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
             "version": "==1.1.1"
         },
         "packaging": {
             "hashes": [
-                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
-                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+                "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73",
+                "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
             ],
-            "version": "==19.2"
+            "version": "==20.1"
         },
         "pygments": {
             "hashes": [
-                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
-                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
+                "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b",
+                "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"
             ],
-            "version": "==2.4.2"
+            "version": "==2.5.2"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
-                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
             ],
-            "version": "==2.4.5"
+            "version": "==2.4.6"
         },
         "pytz": {
             "hashes": [
@@ -158,10 +169,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
-                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.13.0"
+            "version": "==1.14.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -172,11 +183,19 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:31088dfb95359384b1005619827eaee3056243798c62724fd3fa4b84ee4d71bd",
-                "sha256:52286a0b9d7caa31efee301ec4300dbdab23c3b05da1c9024b4e84896fb73d79"
+                "sha256:b3feeed2da588adabd0db5329a309f27317e98382122721511e901833d092028",
+                "sha256:fb2ce74c28154872757925edda0060b4c4102cdc86b8b30063f23399678de2ca"
             ],
             "index": "pypi",
-            "version": "==2.2.1"
+            "version": "==2.4.0"
+        },
+        "sphinx-markdown-tables": {
+            "hashes": [
+                "sha256:08779e77832b6562b6b86e4270ae50b0b10010fdd35cf9aadcb5b8246571b933",
+                "sha256:ecfc7fd2e02c339fcf12eb9cbcf59fedeb5ff54b6fe666df6e0791a03ece9b05"
+            ],
+            "index": "pypi",
+            "version": "==0.0.12"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -230,10 +249,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.25.7"
+            "version": "==1.25.8"
         }
     },
     "develop": {}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ release = '1.0.0'
 # ones.
 extensions = [
     'recommonmark',
+    'sphinx_markdown_tables',
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'sphinx.ext.imgmath',

--- a/docs/infra/irc.md
+++ b/docs/infra/irc.md
@@ -1,0 +1,90 @@
+IRC (Freenode)
+==============
+
+This page documents the [Internet Relay Chat](https://en.wikipedia.org/wiki/Internet_Relay_Chat "Internet Relay Chat - Wikipedia") (IRC) infrastructure for the FOSS@RIT community.
+Currently, this only includes our presence on the [Freenode](https://freenode.net/ "official Freenode website") IRC network.
+
+
+## Project registration
+
+TODO…
+
+
+## Cloaks
+
+Cloaks are a type of "host mask" that replaces your IP address in IRC clients with a custom string of text.
+The IRC protocol exposes your IP address or hostname by default when you join a channel.
+When you authenticate with IRC's NickServ, a cloak replaces your IP address/hostname with the custom string.
+
+Note that Freenode does not support the underscores (`_`) in cloaks.
+Other non-alphanumeric characters may also not be supported and will be omitted from the cloak.
+
+### Request a cloak
+
+In order to receive a cloak, you must have completed the following steps:
+
+1. Register your nick with NickServ
+2. Set an email address with NickServ
+3. Created an alternate nick and linked it to primary nick with NickServ
+
+If you have not completed these steps, Freenode will not allow us to create your cloak.
+For help doing these things, check out the [Nickname Registration help page](https://freenode.net/kb/answer/registration "Nickname Registration - freenode") on Freenode's website.
+
+Once you have completed the above steps, you can request a new cloak.
+Request a cloak by [opening a new issue](https://github.com/FOSSRIT/tasks/issues/new) on the [FOSSRIT/tasks](https://github.com/FOSSRIT/tasks) repository.
+
+### Available cloaks
+
+Members of the RIT community may choose from the following cloaks:
+
+#### General
+
+* `@rit/student/<your IRC nick>`
+* `@rit/professor/<your IRC nick>`
+* `@rit/faculty/<your IRC nick>`
+* `@rit/alumnus/<your IRC nick>`
+* `@rit/alumna/<your IRC nick>`
+* `@rit/alum/<your IRC nick>`
+
+#### RIT FOSS
+
+Cloaks for the [RIT FOSS community](https://fossrit.github.io/about/).
+
+* `@rit/foss/student/<your IRC nick>`
+* `@rit/foss/faculty/<your IRC nick>`
+* `@rit/foss/alumnus/<your IRC nick>`
+* `@rit/foss/alumna/<your IRC nick>`
+* `@rit/foss/alum/<your IRC nick>`
+
+#### RITlug
+
+Cloaks for the [RIT Linux Users Group](https://ritlug.com/about/).
+
+* `@rit/ritlug/member/<your IRC nick>`
+* `@rit/ritlug/alumnus/<your IRC nick>`
+* `@rit/ritlug/alumna/<your IRC nick>`
+* `@rit/ritlug/alum/<your IRC nick>`
+
+### Granted cloaks
+
+The table below is a list of community members who were issued IRC cloaks.
+
+<!--
+Please be mindful for accounts with the character "|".
+You should look at the source because the formatted page does not show "|".
+-->
+
+| Real name        | Email                     | NickServ account | RIT computer account | Cloak                            |
+| ---------------- | ------------------------- | ---------------- | -------------------- | -------------------------------- |
+| Justin W. Flory  | jflory7@gmail.com         | jflory7          | jwf9260              | @rit/foss/captain/fedora.jflory7 |
+| Chris Bitler     | crb2547@rit.edu           | VoidWhisperer    | crb2547              | @rit/foss/student/voidwhisperer  |
+| Adam Hayes       | abraunhayes@gmail.com     | moondoggy        | abhsps               | @rit/alum/moondoggy              |
+| Jennifer Herting | jen@herting.cc            | qwertos          |                      | @rit/alumna/qwertos              |
+| Mike Nolan       | me@michael-nolan.com      | Nolski           | mpn3712              | @rit/foss/alumnus/nolski         |
+| Nate Levesque    | ngl3477@rit.edu           | thenaterhood     | ngl3477              | @rit/alum/thenaterhood           |
+| Aidan Kahrs      | abkahrs@gmail.com         | axk4545          | axk4545              | @rit/ritlug/member/axk4545       |
+| Matt Soucy       | msoucy@csh.rit.edu        | msoucy           | mas5997              | @rit/foss/alumnus/msoucy         |
+| Wilfried Hounyo  | whounyo@gmail.com         | wilfriedE        | weh7221              | @rit/student/wilfriede           |
+| Brendan McGeever | btm4810@rit.edu           | sacratoy         | btm4810              | @rit/foss/student/sacratoy       |
+| Kevin M. Granger | freenode@kevinmgranger.me | KevinMGranger    | kmg2728              | @rit/foss/alum/kevinmgranger     |
+| Christian Martin | ctm2142@rit.edu           | ctmartin         | ctm2142              | @rit/foss/student/ctmartin       |


### PR DESCRIPTION
This commit adds documentation for the IRC cloaks we have on Freenode as
part of our project registration. This content originally lived here,
but has since been archived:

https://github.com/FOSSRIT/library/wiki/RIT-IRC-cloaks

I also updated parts from the old wiki page, including how to request a
cloak.

Closes #9.

![Screenshot of rendered IRC page explaining cloaks](https://user-images.githubusercontent.com/4721034/74191512-c15dc080-4c21-11ea-97ff-d49f026f5d25.png "Screenshot of rendered IRC page explaining cloaks")