### PR TITLE
readthedocs: Add RTD config file, requirements file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: dirhtml
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set Python version and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt
+  system_packages: true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3fa25592848ef814e2b957544e9377506618e64d4234db55b52e0ba4177ab1f7"
+            "sha256": "e97cf3d7e87f3a8a11e202d4744adbeb7f1a3fca4b8f6bcecbb881a2d366af60"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -78,6 +78,13 @@
                 "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
             ],
             "version": "==2.11.1"
+        },
+        "markdown": {
+            "hashes": [
+                "sha256:c00429bd503a47ec88d5e30a751e147dcb4c6889663cd3e2ba0afe858e009baa",
+                "sha256:d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c"
+            ],
+            "version": "==3.0.1"
         },
         "markupsafe": {
             "hashes": [
@@ -176,11 +183,19 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:b3feeed2da588adabd0db5329a309f27317e98382122721511e901833d092028",
-                "sha256:fb2ce74c28154872757925edda0060b4c4102cdc86b8b30063f23399678de2ca"
+                "sha256:5024a67f065fe60d9db2005580074d81f22a02dd8f00a5b1ec3d5f4d42bc88d8",
+                "sha256:f929b72e0cfe45fa581b8964d54457117863a6a6c9369ecc1a65b8827abd3bf2"
             ],
             "index": "pypi",
-            "version": "==2.4.0"
+            "version": "==2.4.1"
+        },
+        "sphinx-markdown-tables": {
+            "hashes": [
+                "sha256:08779e77832b6562b6b86e4270ae50b0b10010fdd35cf9aadcb5b8246571b933",
+                "sha256:ecfc7fd2e02c339fcf12eb9cbcf59fedeb5ff54b6fe666df6e0791a03ece9b05"
+            ],
+            "index": "pypi",
+            "version": "==0.0.12"
         },
         "sphinx-rtd-theme": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ docutils==0.16
 idna==2.8
 imagesize==1.2.0
 jinja2==2.11.1
+markdown==3.0.1
 markupsafe==1.1.1
 packaging==20.1
 pygments==2.5.2
@@ -17,8 +18,9 @@ recommonmark==0.6.0
 requests==2.22.0
 six==1.14.0
 snowballstemmer==2.0.0
+sphinx-markdown-tables==0.0.12
 sphinx-rtd-theme==0.4.3
-sphinx==2.4.0
+sphinx==2.4.1
 sphinxcontrib-applehelp==1.0.1
 sphinxcontrib-devhelp==1.0.1
 sphinxcontrib-htmlhelp==1.0.2


### PR DESCRIPTION
ReadTheDocs.org builds are still failing. This follows the suggestion in
the build failure by using the `.readthedocs.yml` config file to specify
some of the build instructions.

Also, somehow the `sphinx-markdown-tables` dependency was omitted in the
`requirements.txt` file, which was the root problem I was battling.

Verification that this is _actually_ building now, srsly:

https://readthedocs.org/projects/fossrit-runbook/builds/10419590/