### PR TITLE
tech-team: Initial commit (closes #7)

### DIFF
--- a/docs/community/tech-team.md
+++ b/docs/community/tech-team.md
@@ -1,0 +1,43 @@
+FOSS@RIT Tech Team
+==================
+
+This page explains what the FOSS@RIT Tech Team is, the responsibilities of the team, and where to contact the Tech Team.
+
+
+## What is Tech Team?
+
+The FOSS@RIT Tech Team is a group of FOSS@MAGIC staff, RIT faculty, students, and alums who support the infrastructure and digital services of the FOSS@RIT community.
+The Tech Team was launched in Spring 2020, as part of an [open call for volunteers](https://fossrit.github.io/announcements/2019/12/17/spring-2020-volunteers/) for FOSS@MAGIC.
+The team is volunteer-driven and loosely under the leadership of FOSS@MAGIC staff.
+
+For information about joining the Tech Team, see [Joining Tech Team](/policy/join-tech-team).
+
+
+## Responsibilities
+
+Generally, the FOSS@RIT Tech Team assists with these areas:
+
+* Infrastructure management and administration (more info in [Infrastructure and services](/index#infra) of the Runbook)
+* Software development
+* Peer reviews (on code/infrastructure pull requests)
+* Early access to FOSS@MAGIC technology experiments
+
+### Projects
+
+Examples of projects the Tech Team focuses on are listed below:
+
+* [**FOSSRIT/foss-profiles**](https://github.com/FOSSRIT/foss-profiles): Generate a web page for FOSS@RIT community members from YAML profiles
+* [**FOSSRIT/fossrit.github.io**](https://github.com/FOSSRIT/fossrit.github.io): Official website for Free and Open Source Software @ RIT MAGIC Center and FOSS academia
+* [**FOSSRIT/infrastructure**](https://github.com/FOSSRIT/infrastructure): Set of scripts, Ansible playbooks/roles, and other tools to automate and manage FOSS@MAGIC infrastructure
+* [**FOSSRIT/runbook**](https://github.com/FOSSRIT/runbook): Documentation and information about the Free and Open Source community at RIT, facilitated by RIT MAGIC Center
+* [**RITlug/teleirc**](https://github.com/RITlug/teleirc): Telegram <=> IRC bridge for use with any IRC channel and Telegram group
+
+
+## Contact
+
+The FOSS@RIT Tech Team is on Discourse, IRC, and Telegram.
+Come say hi!
+
+* **Discourse**: [FOSSRIT - Projects](https://fossrit.community/c/rit/projects/9)
+* **IRC (Freenode)**: [#rit-foss-admin](ircs://chat.freenode.net:6697/#rit-foss-admin)
+* **Telegram**: [@fossrit_techteam](https://t.me/fossrit_techteam)

--- a/docs/policy/join-tech-team.md
+++ b/docs/policy/join-tech-team.md
@@ -1,0 +1,29 @@
+Joining Tech Team
+=================
+
+This page provides guidance for new volunteers and maintainers on how to bring new people into the FOSS@RIT Tech Team.
+It is assumed you already read the [FOSS@RIT Tech Team](/community/tech-team) documentation.
+
+<!-- This page is barebones for now, but as other docs progress, expect this to be updated more too. -->
+
+
+## For new volunteers
+
+1. Fill out the [volunteer sign-up form](https://forms.gle/Q3GUYC32ft3GRiL39)
+1. Join the IRC/Telegram chat and say hello, briefly introduce yourself
+1. Keep an eye out for email follow-up from a Tech Team maintainer
+
+
+## For maintainers
+
+This section describes the process for Tech Team maintainers or FOSS@MAGIC staff to bring new people into the Tech Team.
+
+1. Conduct a 30 minute, 1x1 interview with new volunteer about why they want to get involved, their interests, and anything they think is important for FOSS@MAGIC to work on
+1. Invite them to Tech Team chat groups / Discourse forum
+1. Invite them to recurring meetings, or if meeting time not decided yet, send them a poll for choosing the best time
+1. After their participation in first meeting, add them to relevant GitHub org groups <!-- More to be written here once the GitHub doc is done. -->
+1. Communicate regularly and run occasional check-ins to see if new volunteer is getting what they want out of participating and if there is anything that could be improved
+
+**NOTE**: Participation in the meetings is critical and all members of the Tech Team should make an effort to attend these meetings.
+This is one of the few opportunities for everyone to check in together, see how things are going, and raise issues to the rest of the group.
+When bringing on new members, emphasize the importance of these occasional meetings and ensure they understand the importance of committing to these meetings.


### PR DESCRIPTION
This commit adds _two_ new docs, whooaaaa! This is a first step to
documenting what the FOSS@RIT Tech Team is, and also leaves a loose
blueprint of how to get involved with the Tech Team.

The first page (`community/tech-team`) focuses on defining what the
FOSS@RIT Tech Team is, what some of their responsibilities and projects
are, and how to get in touch with folks.

The second page (`policy/join-tech-team`) provides instructions both for
new volunteers and maintainers of the Tech Team on how to on-board new
people. It is a barebones page right now and I expect to add onto it
over time (like once the GitHub organization docs page is done). But
this puts down something for the time being, and it can be iterated on
over time.

Closes #7.

![Screenshot of Community -> Tech Team page, generated from local development environment](https://user-images.githubusercontent.com/4721034/74952475-4db07600-53ce-11ea-8286-1ba4d90a97b7.png "Screenshot of Community -> Tech Team page, generated from local development environment")

![Screenshot of Policy -> Joining Tech Team page, generated from local development environment](https://user-images.githubusercontent.com/4721034/74952504-5903a180-53ce-11ea-9a21-d9c88aa482a5.png "Screenshot of Policy -> Joining Tech Team page, generated from local development environment")