### PR TITLE
discourse: Explain DO firewall (closes FOSSRIT/infrastructure#44)

### DIFF
--- a/docs/infra/discourse.md
+++ b/docs/infra/discourse.md
@@ -25,7 +25,7 @@ This host runs:
 
 This host relies on:
 
-* SendGrid API key (for outgoing mail, eventually incoming)
+* SendGrid API key (for outgoing mail only)
 
 
 ## Deploying
@@ -41,6 +41,13 @@ Our Discourse site was deployed exactly as described in upstream's documentation
 We do not use config files to maintain Discourse.
 The config settings are dynamic and stored inside the image container.
 If a rollback is needed, see [Backups](#backups).
+
+### Firewall
+
+Note that DigitalOcean maintains its own firewall, a layer above the Linux Droplet where the Discourse forum is hosted.
+If adding or changing ports on a DigitalOcean Droplet, make sure the ports you need opened are added to the Droplet firewall in the DigitalOcean admin panel.
+See the [DigitalOcean](digitalocean) page for more information about accessing the admin panel.
+See [FOSSRIT/infrastructure#44](https://github.com/FOSSRIT/infrastructure/issues/44) for additional historical context.
 
 
 ## Upgrading


### PR DESCRIPTION
This commit adds documentation for an obscure issue when it comes to
updating any of the DigitalOcean infrastructure associated with the
Discourse forum. More details are explained in the changed lines in the
commit and FOSSRIT/infrastructure#44.

Closes FOSSRIT/infrastructure#44.