### PR TITLE
contact: Add link to @ritjoe's blog post (closes #36)

### DIFF
--- a/docs/about/contact.md
+++ b/docs/about/contact.md
@@ -18,6 +18,8 @@ However, the FOSS@RIT identity is not exclusive.
 It is not "owned" by any single group or organization.
 Generally, anyone who works in free/open communities at RIT, not limited to software, is included in this identity.
 
+See Prof. Deejoe's blog post with suggestions on how to get involved with the FOSS@RIT community: [Joining RIT@FOSS](https://web.archive.org/web/20200225161814/http://deejoe.etrumeus.com/update/joining-ritfoss.html)
+
 ### Responsibilities
 
 Responsibilities associated with the FOSS@RIT community are typically on a volunteer basis and informal.


### PR DESCRIPTION
This commit adds a link to an archive.org page of @ritjoe's blog post
with ways on getting involved with the FOSS@RIT community. It's a small
addition but I thought it was helpful to put here for now.

Closes #36.