### PR TITLE
community: Add Election Night Hackathon guide (closes #17)

### DIFF
--- a/docs/community/election-night-guide.md
+++ b/docs/community/election-night-guide.md
@@ -1,0 +1,158 @@
+Election Night Hackathon: Organizer's guide
+===========================================
+
+This page is an organizer's guide for the **RIT Election Night Hackathon** (ENH).
+It provides context on what the ENH is, how to organize one, and a historical reference of past ENHs.
+
+
+## What is it?
+
+ENH is a traditional event hosted by FOSS@MAGIC every November on Election Night in the United States.
+It is a night to celebrate the tradition of democracy in the United States by working on civic-focused projects (or in many cases, assignments due the next day).
+While projects are often technology-focused, the scope is beyond technology too.
+It is also a place for our community to gather and make connections with folks who do not typically participate in the wider FOSS@RIT community.
+
+
+## How to organize
+
+Sections below are in sequential order.
+
+### Reserve venue
+
+First, reserve a venue for the ENH.
+Attendance varies depending if it is a presidential election year or not.
+On presidential election years, attendee counts are around 100 people.
+On midterm election years, attendee counts are between 10 to 30 people.
+Choose a venue accordingly.
+
+Typically, venue logistics are worked out in partnership with the RIT MAGIC Center.
+
+### Set up RSVP system
+
+Next, set up some sort of system to collect RSVPs for the event.
+
+Historically we have used Eventbrite for this.
+The Eventbrite account is a personal account for individual student employees; there is not a shared FOSS@MAGIC Eventbrite account.
+However, note discussion about switching to the Meetup.com platform in [FOSSRIT/tasks#112](https://github.com/FOSSRIT/tasks/issues/112 "FOSSRIT/tasks#112: Consider moving from Eventbrite to Meetup.com").
+Whichever system is used, the only critical requirement is a free and easy way for community members to RSVP with an email address so we can order an appropriate amount of food.
+
+### Publish ENH on FOSS@MAGIC website
+
+The ENH needs an event profile on the FOSS@MAGIC website.
+This provides us a static link to share for community outreach and promotion.
+See [Website - How to create events](/infra/website "Scroll down to 'How to create events' section") for how to do this.
+
+### Promote ENH
+
+Once the event profile is published and RSVP system is in place, begin promoting the event.
+Typically we share the event profile on the FOSS@MAGIC website in the following places:
+
+* [FOSSRIT Discourse](https://fossrit.community/c/rit/7)
+* [FOSSRIT mailing list](https://lists.fedoraproject.org/admin/lists/fossrit.lists.fedorahosted.org/) (technically retired, but some people still hang out only here)
+* [RIT subreddit](https://www.reddit.com/r/rit/)
+* [Rochester subreddit](https://www.reddit.com/r/rochester/)
+* Various community Slacks (ask community for help on this one!)
+    * [codeRIT Slack](https://coderit.slack.com/)
+    * [RITlug Slack](https://rit-lug.slack.com/)
+    * [Women in Computing Slack](https://ritwic.slack.com/)
+
+### Reach out to community organizations
+
+Sometimes we partner with local community organizations for the ENH.
+For example, [in 2019](https://fossrit.github.io/events/2019/11/05/election-night-hackathon/), a hackathon activity involved transcribing suffagist papers in collaboration with the Smithsonian and the Library of Congress.
+We have also partnered with other organizations like WXXI and [Second Avenue Learning](https://secondavenuelearning.com/).
+
+Ask for support from FOSS@MAGIC staff on this task.
+
+### Recruit volunteers
+
+Having 3-4 volunteers for the night makes life as an organizer much easier.
+Volunteer responsibilities typically include the following:
+
+* Help unpack food when it arrives
+* Run registration desk / check-in arriving participants
+* Provide/share stickers near registration desk
+* Set up tables / power sources, if applicable
+* Answer questions from attendees, direct to someone who can help if they cannot
+
+It is not a lot of work and when there are a few people helping out, it reduces the stress factor significantly.
+Publish an announcement on the FOSS@MAGIC website with a Google Form for volunteer sign-ups.
+Usually a firm schedule is not necessary, but make sure to get an idea of how long each volunteer can spend at the hackathon.
+Get final confirmations from volunteers about 1-2 weeks before the ENH.
+
+### Pre-order food/drinks
+
+The afternoon of the ENH, pre-order food and drinks based on current RSVP counts.
+Note from past experience, a lot of RSVPs will not show and there will be a fair amount of people who walk in by chance.
+Try to accommodate diverse dietary needs _especially_ if ordering pizza, e.g. gluten-free options, vegan options, vegetarian pizzas, etc.
+
+It could be a good idea to include this as a registration question in the RSVP system in the future.
+
+### Prepare kick-off materials
+
+Prepare an introductory slide deck and any speaker notes to kick off the ENH.
+This happens in the first 30 minutes of the hackathon.
+It usually includes the following:
+
+* Introduction to FOSS@MAGIC
+* Introduction to any partner organizations
+* Logistics for the evening
+    * Share public lists of resources, if any (e.g. links to civic APIs, public data sources, etc.)
+    * When hacking ends
+    * When project demos begin
+    * Details on prizes, if any (we usually don't though)
+
+This is usually led by FOSS@MAGIC staff, but there is no reason why a student volunteer cannot help co-lead this part too.
+
+### Have fun!
+
+Have fun and let the hacking begin!
+Coordinate with volunteers as needed depending on overall crowd size.
+If it is a presidential election year, be mindful of building fire code for how many people can be in one space at a time.
+
+
+## Historical archive
+
+This section is an informal collection of blog posts, tweets, event reports, and other media related to the Election Night Hackathon at RIT:
+
+### 2019
+
+* 2019-11-05: [Election Night Hackathon 2019](https://fossrit.github.io/events/2019/11/05/election-night-hackathon/) (Justin W. Flory)
+
+### 2018
+
+* 2018-12-08: [2018 In Review](https://jrtechs.net/other/2018-in-review) (Jeffery Russell)
+* 2018-11-06: [Election Night Hackathon 2018](https://fossrit.github.io/events/2018/11/06/election-night-hackathon/) (Justin W. Flory)
+* 2018-11-06: [8th Annual Election Night Hackathon - 2018 midterms](https://www.hackathon.com/event/8th-annual-election-night-hackathon---2018-midterms-51634099983) (hackathon.com)
+
+### 2017
+
+* 2017-12-11: [Election night hackathon supports civic engagement](https://opensource.com/article/17/12/rit-election-night-hackathon) (Justin W. Flory)
+* 2017-11-13: [“Where can I vote?” — RIT Election Night Hackathon 2017](https://medium.com/@crb2547/where-can-i-vote-rit-election-night-hackathon-2017-1b6119559822) (Chris Bitler)
+
+### 2016
+
+* 2016-12-14: [Students and professors work across the aisle during Election Night Hackathon](https://opensource.com/article/16/12/2016-election-night-hackathon) (Justin W. Flory)
+* 2016-11-07: [Election Night Hackathon](https://muse.union.edu/makerweb/2016/11/07/election-night-hackathon/) (ervina)
+* 2016-10-25: [Election Night Hackathon: November 8, 5pm-11:30pm](https://ritlug.com/announcements/2016/10/25/election-night-hackathon/) (RITlug)
+* 2016-10-18: [Hack the elections! Annual Election Night Hackathon @ MAGIC Center](https://www.reddit.com/r/rit/comments/586efd/hack_the_elections_annual_election_night/) (Reddit)
+
+### 2015
+
+* 2015-11-03: [RIT MAGIC Center on Twitter: "Our 5th annual election night hackathon is in full swing…"](https://twitter.com/ritmagic/status/661729504457572353) (RIT MAGIC Center)
+
+### 2014
+
+* 2014-12-02: [Election Night Hackathon 2014](https://msoucy.me/2014/12/election-night-2014/) (Matt Soucy)
+
+### 2013
+
+* 2013-08-28: [Election Night 2013](http://www.samlucidi.com/fossbox/event-decause-election-night-2013.html) (Remy DeCausemaker)
+
+### 2011
+
+* 2011-11-06: [RIT Election Night Hackathon](http://www.samlucidi.com/fossbox/event-decause-rit-election-night-hackathon.html) (Remy DeCausemaker)
+
+### 2010
+
+* 2010-11-04: [Election Night Hackathon 2010](https://fossrit.github.io/events/2010/11/04/election-night-hackathon/) (Remy DeCausemaker)


### PR DESCRIPTION
This is an initial commit of an organizer's guide for the RIT Election
Night Hackathon, an annual tradition organized by FOSS@MAGIC each year
in November on U.S. election night.

I tried to give some context for the event and provide sequential steps
on things we do when we are pulling this together each year. Also, I
added a historical archive of past events to hopefully give some sort of
reference for future organizers about what we have done in the past.

Closes #17.

cc: @itprofjacobs 

![Screenshot of local preview](https://user-images.githubusercontent.com/4721034/75478493-1280ea80-596c-11ea-8159-dd913458eb58.png "Screenshot of local preview")