### PR TITLE
index: Drop miscellaneous category

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,14 +32,6 @@ For more information, see the `repo on GitHub <https://github.com/FOSSRIT/runboo
 
 .. toctree::
     :maxdepth: 2
-    :name: misc
-    :caption: Miscellaneous:
-    :glob:
-
-    misc/*
-
-.. toctree::
-    :maxdepth: 2
     :name: infra
     :caption: Infrastructure and services:
     :glob:


### PR DESCRIPTION
I created this when outlining the repository structure, but now that
things are almost done, everything I've written has neatly fallen into
the other categories. Since I don't know what to include here and it
throws an annoying warning in Sphinx, I'm dropping it from the index.