### PR TITLE
Add issue templates (closes #2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-outdated-info.md
+++ b/.github/ISSUE_TEMPLATE/01-outdated-info.md
@@ -1,0 +1,22 @@
+---
+name: Incorrect or outdated information
+about: Something in the Runbook is wrong or out of date
+title: 'Info update needed: '
+labels: bug, needs triage
+assignees: ''
+
+---
+
+# Summary
+
+<!-- Give a **one-sentence summary** of what is incorrect or outdated. -->
+
+
+# Suggested change
+
+<!-- What do we need to do to make this right? Can you suggest what changes are needed to resolve your report? If you don't know, it is okay to say so. -->
+
+
+# Other details
+
+<!-- Want to include other details? Explain them here. If you have any debugging thoughts, put them here. -->

--- a/.github/ISSUE_TEMPLATE/02-new-documentation.md
+++ b/.github/ISSUE_TEMPLATE/02-new-documentation.md
@@ -1,0 +1,32 @@
+---
+name: New documentation
+about: Something needs to be added to the Runbook
+title: 'New addition: '
+labels: needs triage, new change
+assignees: ''
+
+---
+
+# Summary
+
+<!-- Describe what needs to be documented in one sentence. -->
+
+
+# Background
+
+<!-- What do we need to know to document this? Is any research needed? Why is it important we document this? This helps understand the "why" of your request. -->
+
+
+# Details
+
+<!-- Write an outline of what this document should include in an ordered list. -->
+
+1.
+2.
+3.
+4.
+
+
+# Outcome
+
+<!-- In one sentence, explain the impact of documenting what you described above. -->

--- a/.github/ISSUE_TEMPLATE/03-general-improvement.md
+++ b/.github/ISSUE_TEMPLATE/03-general-improvement.md
@@ -1,0 +1,27 @@
+---
+name: General improvement
+about: Could something be better? Tell us how.
+title: ''
+labels: improvement, needs triage
+assignees: ''
+
+---
+
+# Summary
+
+<!-- Describe your improvement in one sentence. -->
+
+
+# Background
+
+<!-- What background info do we need to understand your suggestion? Help us understand the "why" part of your suggestion here.  -->
+
+
+# Details
+
+<!-- What does completing your suggestion look like? Give us an idea of what a satisfactory job looks like to you. -->
+
+
+# Outcome
+
+<!-- In one sentence, explain the impact of implementing your suggestion. -->

--- a/.github/ISSUE_TEMPLATE/04-other.md
+++ b/.github/ISSUE_TEMPLATE/04-other.md
@@ -1,0 +1,10 @@
+---
+name: Other
+about: Something that doesn't belong elsewhere
+title: ''
+labels: needs triage
+assignees: ''
+
+---
+
+<!-- This is a free-form ticket. You decide how to write it. Please add background and details if this is not a quick fix or change. -->


### PR DESCRIPTION
This commit adds a set of issue templates based on what I anticipate
future people will open issues for on this repository. There are
templates for the following scenarios:

* Incorrect/outdated documentation
* Need for new documentation
* General improvement (e.g. for contributor experience or CI)
* Other (catch-all for anything else)

The issue templates help others structure their requests to the
FOSS@MAGIC team and also saves a little bit of time by using the set of
labels that I am in a habit of using for categorizing things.

Closes #2.