### PR TITLE
ci: Cache pip packages for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
+---
 os: linux
-jobs:
-  include:
-    - language: python
-      python: 3.7
-      install:
-        - pip install pipenv
-        - pipenv install
-      script: docs/build_docs.sh
+dist: bionic
+
+language: python
+python: 3.7
+cache: pip
+
+install: "pip install $(pipenv lock --requirements)"
+script: docs/build_docs.sh
 
 notifications:
   irc:


### PR DESCRIPTION
This configures Travis CI to cache packages installed by Python's `pip`
installer during build set-up. The cache is only updated if the
dependencies change in the `Pipfile.lock` file. Since the Runbook isn't
**that** complicated of a project, this might only save 10-20 seconds of
time, but hey.